### PR TITLE
Add max depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ You cancustomize the action by using the following variables:
 - `folder-path`: By default the `github-action-markdown-link-check` action
   checks for all markdown files in your repository. Use this option to limit
   checks to only specific folders.
+- `max-depth`: Specify how many levels deep you want to check in the directory
+  structure. By default this is not set, using e.g. `1` will limit to
+  top-level directory only or `folder-path` only, if set.
 
 #### Sample workflow with variables
 
@@ -55,6 +58,7 @@ jobs:
         use-verbose-mode: 'yes'
         config-file: 'mlc_config.json'
         folder-path: 'docs/markdown_files'
+        max-depth: 2
 ```
 
 ### Scheduled runs

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Specify path to a custom folder where your markdown files are located.'
     required: true
     default: '.'
+  max-depth:
+    description: 'Specify a max-depth of directories you want to search for markdown files.'
+    required: true
+    default: '-1'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -31,3 +35,4 @@ runs:
     - ${{ inputs.use-verbose-mode }}
     - ${{ inputs.config-file }}
     - ${{ inputs.folder-path }}
+    - ${{ inputs.max-depth }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,11 +23,6 @@ echo -e "${BLUE}MAX_DEPTH: $5${NC}"
 FIND_CALL="find ${FOLDER_PATH} -name \*.md -not -path './node_modules/*' -exec markdown-link-check {}"
 
 if [ -f "$CONFIG_FILE" ]; then
-   if [ "$USE_QUIET_MODE" = "yes" ]; then
-      if [ "$USE_VERBOSE_MODE" = "yes" ]; then
-         echo -e "${BLUE}I found config file ${NC}"
-      fi
-   fi
    echo -e "${BLUE}Using markdown-link-check configuration file: ${YELLOW}$CONFIG_FILE${NC}"
    FIND_CALL+=" --config ${CONFIG_FILE}"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,10 +13,12 @@ USE_QUIET_MODE="$1"
 USE_VERBOSE_MODE="$2"
 CONFIG_FILE="$3"
 FOLDER_PATH="$4"
+MAX_DEPTH="$5"
 
 echo -e "${BLUE}USE_QUIET_MODE: $1${NC}"
 echo -e "${BLUE}USE_VERBOSE_MODE: $2${NC}"
 echo -e "${BLUE}FOLDER_PATH: $4${NC}"
+echo -e "${BLUE}MAX_DEPTH: $5${NC}"
 
 FIND_CALL="find ${FOLDER_PATH} -name \*.md -not -path './node_modules/*' -exec markdown-link-check {}"
 
@@ -33,6 +35,9 @@ else
    echo -e "${YELLOW}NOTE: See https://github.com/tcort/markdown-link-check#config-file-format to know more about"
    echo -e "customizing markdown-link-check by using a configuration file.${NC}"
 fi
+if [ "$5" -ne -1 ]; then
+   FIND_CALL+=" --maxdepth ${MAX_DEPTH}"
+fi
 
 if [ "$USE_QUIET_MODE" = "yes" ]; then
    FIND_CALL+=" -q"
@@ -45,7 +50,7 @@ fi
 FIND_CALL+=" \; &>> error.txt"
 
 set -x
-echo "$FIND_CALL" | sh
+eval "$FIND_CALL"
 set +x
 
 if [ -e error.txt ] ; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,80 +18,35 @@ echo -e "${BLUE}USE_QUIET_MODE: $1${NC}"
 echo -e "${BLUE}USE_VERBOSE_MODE: $2${NC}"
 echo -e "${BLUE}FOLDER_PATH: $4${NC}"
 
-if [ "$USE_QUIET_MODE" = "yes" ]; then
+FIND_CALL="find ${FOLDER_PATH} -name \*.md -not -path './node_modules/*' -exec markdown-link-check {}"
 
-   if [ "$USE_VERBOSE_MODE" = "yes" ]; then
-
-      if [ -f "$CONFIG_FILE" ]; then
+if [ -f "$CONFIG_FILE" ]; then
+   if [ "$USE_QUIET_MODE" = "yes" ]; then
+      if [ "$USE_VERBOSE_MODE" = "yes" ]; then
          echo -e "${BLUE}I found config file ${NC}"
-         echo -e "${BLUE}Using markdown-link-check configuration file: ${YELLOW}$CONFIG_FILE${NC}"
-         set -x
-         find "$FOLDER_PATH" -name \*.md -not -path "./node_modules/*" -exec markdown-link-check {} --config "$CONFIG_FILE" -vq \; &>> error.txt
-         set +x
-      else
-         echo -e "${BLUE}Cannot find ${YELLOW}$CONFIG_FILE${NC}"
-         echo -e "${YELLOW}NOTE: See https://github.com/tcort/markdown-link-check#config-file-format to know more about"
-         echo -e "customizing markdown-link-check by using a configuration file.${NC}"
-         set -x
-         find "$FOLDER_PATH" -name \*.md -not -path "./node_modules/*" -exec markdown-link-check {} -vq \; &>> error.txt
-         set +x
       fi
-
-   else
-
-      if [ -f "$CONFIG_FILE" ]; then
-         echo -e "${BLUE}Using markdown-link-check configuration file: ${YELLOW}$CONFIG_FILE${NC}"
-         set -x
-         find "$FOLDER_PATH" -name \*.md -not -path "./node_modules/*" -exec markdown-link-check {} --config "$CONFIG_FILE" -q \; &>> error.txt
-         set +x
-      else
-         echo -e "${BLUE}Cannot find ${YELLOW}$CONFIG_FILE${NC}"
-         echo -e "${YELLOW}NOTE: See https://github.com/tcort/markdown-link-check#config-file-format to know more about"
-         echo -e "customizing markdown-link-check by using a configuration file.${NC}"
-         set -x
-         find "$FOLDER_PATH" -name \*.md -not -path "./node_modules/*" -exec markdown-link-check {} -q \; &>> error.txt
-         set +x
-      fi
-
    fi
-
+   echo -e "${BLUE}Using markdown-link-check configuration file: ${YELLOW}$CONFIG_FILE${NC}"
+   FIND_CALL+=" --config ${CONFIG_FILE}"
 else
-
-   if [ "$USE_VERBOSE_MODE" = "yes" ]; then
-
-      if [ -f "$CONFIG_FILE" ]; then
-         echo -e "${BLUE}Using markdown-link-check configuration file: ${YELLOW}$CONFIG_FILE${NC}"
-         set -x
-         find "$FOLDER_PATH" -name \*.md -not -path "./node_modules/*" -exec markdown-link-check {} --config "$CONFIG_FILE" -v \; &>> error.txt
-         set +x
-      else
-         echo -e "${BLUE}Cannot find ${YELLOW}$CONFIG_FILE${NC}"
-         echo -e "${YELLOW}NOTE: See https://github.com/tcort/markdown-link-check#config-file-format to know more about"
-         echo -e "customizing markdown-link-check by using a configuration file.${NC}"
-         set -x
-         find "$FOLDER_PATH" -name \*.md -not -path "./node_modules/*" -exec markdown-link-check {} -v \; &>> error.txt
-         set +x
-      fi
-
-   else
-
-      if [ -f "$CONFIG_FILE" ]; then
-         echo -e "${BLUE}Using markdown-link-check configuration file: ${YELLOW}$CONFIG_FILE${NC}"
-         set -x
-         find "$FOLDER_PATH" -name \*.md -not -path "./node_modules/*" -exec markdown-link-check {} --config "$CONFIG_FILE" \; &>> error.txt
-         set +x
-      else
-         echo -e "${BLUE}Cannot find ${YELLOW}$CONFIG_FILE${NC}"
-         echo -e "${YELLOW}NOTE: See https://github.com/tcort/markdown-link-check#config-file-format to know more about"
-         echo -e "customizing markdown-link-check by using a configuration file.${NC}"
-         set -x
-         find "$FOLDER_PATH" -name \*.md -not -path "./node_modules/*" -exec markdown-link-check {} \; &>> error.txt
-         set +x
-      fi
-
-   fi
-
+   echo -e "${BLUE}Cannot find ${YELLOW}$CONFIG_FILE${NC}"
+   echo -e "${YELLOW}NOTE: See https://github.com/tcort/markdown-link-check#config-file-format to know more about"
+   echo -e "customizing markdown-link-check by using a configuration file.${NC}"
 fi
+
+if [ "$USE_QUIET_MODE" = "yes" ]; then
+   FIND_CALL+=" -q"
+fi
+
+if [ "$USE_VERBOSE_MODE" = "yes" ]; then
+   FIND_CALL+=" -v"
+fi
+
+FIND_CALL+=" \; &>> error.txt"
+
+set -x
+echo "$FIND_CALL" | sh
+set +x
 
 if [ -e error.txt ] ; then
   if grep -q "ERROR:" error.txt; then


### PR DESCRIPTION
In this PR I

- add the option to pass `max-depth` to allow specifying how deep to search for markdown files (in our case, I wanted just the markdown files at the top level)
- took the liberty of deduplicating `entrypoint.sh` somewhat

Let me know what you think. :-)