### PR TITLE
Enable multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GitHub Action - Markdown link check 🔗✔️
-[![GitHub Marketplace](https://img.shields.io/badge/GitHub%20Marketplace-Markdown%20link%20check-brightgreen?style=for-the-badge)](https://github.com/marketplace/actions/markdown-link-check)
+[![GitHub Marketplace](https://img.shields.io/badge/GitHub%20Marketplace-Markdown%20link%20check-brightgreen?style=for-the-badge)](https://github.com/marketplace/actions/markdown-link-check) [![HitCount](http://hits.dwyl.com/gaurav-nelson/github-action-markdown-link-check.svg)](http://hits.dwyl.com/gaurav-nelson/github-action-markdown-link-check)
 
 This GitHub action checks all Markdown files in your repository for broken links. (Uses [tcort/markdown-link-check](https://github.com/tcort/markdown-link-check))
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,9 +94,9 @@ if [ "$CHECK_MODIFIED_FILES" = "yes" ]; then
 else
 
    if [ "$5" -ne -1 ]; then
-      FIND_CALL=('find' "${FOLDER_PATH}" '-name' '*'"${FILE_EXTENSION}" '-not' '-path' './node_modules/*' '-maxdepth' "${MAX_DEPTH}" '-exec' 'markdown-link-check' '{}')
+      FIND_CALL=('find' ${FOLDER_PATH} '-name' '*'"${FILE_EXTENSION}" '-not' '-path' './node_modules/*' '-maxdepth' "${MAX_DEPTH}" '-exec' 'markdown-link-check' '{}')
    else
-      FIND_CALL=('find' "${FOLDER_PATH}" '-name' '*'"${FILE_EXTENSION}" '-not' '-path' './node_modules/*' '-exec' 'markdown-link-check' '{}')
+      FIND_CALL=('find' ${FOLDER_PATH} '-name' '*'"${FILE_EXTENSION}" '-not' '-path' './node_modules/*' '-exec' 'markdown-link-check' '{}')
    fi
 
    if [ -f "$CONFIG_FILE" ]; then


### PR DESCRIPTION
This fixes https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/41#issuecomment-664816921.

Drawback: Folder paths with space in them have to be provided in quotes.

Will test soon.