### PR TITLE
Update to markdown-link-check version 3.8.7

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
 RED='\033[0;31m'
 
-npm i -g markdown-link-check@3.8.6
+npm i -g markdown-link-check@3.8.7
 
 declare -a FIND_CALL
 declare -a COMMAND_DIRS COMMAND_FILES


### PR DESCRIPTION
To use the new markdown-link-extractor that in turn will get a newer version of `marked`