### PR TITLE
Use a group, not manual formatting of results

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,17 +87,17 @@ check_errors () {
 
    if [ -e error.txt ] ; then
       if grep -q "ERROR:" error.txt; then
-         echo -e "${YELLOW}=========================> MARKDOWN LINK CHECK <=========================${NC}"
+         echo "::group::Markdown link check"
          cat error.txt
          printf "\n"
-         echo -e "${YELLOW}=========================================================================${NC}"
+         echo "::endgroup::"
          exit 113
       else
-         echo -e "${YELLOW}=========================> MARKDOWN LINK CHECK <=========================${NC}"
+         echo "::group::Markdown link check"
          printf "\n"
          echo -e "${GREEN}[✔] All links are good!${NC}"
          printf "\n"
-         echo -e "${YELLOW}=========================================================================${NC}"
+         echo "::endgroup::"
       fi
    else
       echo -e "${GREEN}All good!${NC}"


### PR DESCRIPTION
Uses the [`::group` workflow command](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#grouping-log-lines) to group the results instead of printing ASCII delimiters.