### PR TITLE
Update markdown-lint-check to v3.10.0.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
 RED='\033[0;31m'
 
-npm i -g markdown-link-check@3.9.3
+npm i -g markdown-link-check@3.10.0
 
 declare -a FIND_CALL
 declare -a COMMAND_DIRS COMMAND_FILES


### PR DESCRIPTION
This version includes a fix for #anchor links.
See https://github.com/tcort/markdown-link-check/issues/91.