### PR TITLE
Respect folder-path when check-modified-files-only == yes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -168,7 +168,8 @@ if [ "$CHECK_MODIFIED_FILES" = "yes" ]; then
 
    add_options
 
-   mapfile -t FILE_ARRAY < <( git diff --name-only --diff-filter=AM "$MASTER_HASH" )
+   FOLDER_ARRAY=(${FOLDER_PATH//,/ })
+   mapfile -t FILE_ARRAY < <( git diff --name-only --diff-filter=AM "$MASTER_HASH" -- "${FOLDER_ARRAY[@]}")
 
    for i in "${FILE_ARRAY[@]}"
       do


### PR DESCRIPTION
Fixes #167 

This PR leverages `-- <path>...` options of `git diff [<options>] [<commit>] [--] [<path>…​]`
Refer https://git-scm.com/docs/git-diff

I've tested the results of `git diff --name-only --diff-filter=AM "$MASTER_HASH" -- "${FOLDER_ARRAY[@]}"` with some variants of `FOLDER_PATH` in bash. 

```bash
$ FOLDER_PATH="."
$ FOLDER_ARRAY=(${FOLDER_PATH//,/ })
$ git diff --name-only --diff-filter=AM "$MASTER_HASH" -- "${FOLDER_ARRAY[@]}"
.github/workflows/linkcheck.yml
docs/running.md
docs/scalafix-migrations.md
modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
modules/docs/mdoc/running.md
modules/docs/mdoc/scalafix-migrations.md


$ FOLDER_PATH="docs"
$ FOLDER_ARRAY=(${FOLDER_PATH//,/ })
$ git diff --name-only --diff-filter=AM "$MASTER_HASH" -- "${FOLDER_ARRAY[@]}"
docs/running.md
docs/scalafix-migrations.md


$ FOLDER_PATH="docs,modules"
$ FOLDER_ARRAY=(${FOLDER_PATH//,/ })
$ git diff --name-only --diff-filter=AM "$MASTER_HASH" -- "${FOLDER_ARRAY[@]}"
docs/running.md
docs/scalafix-migrations.md
modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
modules/docs/mdoc/running.md
modules/docs/mdoc/scalafix-migrations.md
```

## Reference

