### PR TITLE
Bump markdown-link-check to 3.13.7

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
 RED='\033[0;31m'
 
-npm i -g markdown-link-check@3.13.6
+npm i -g markdown-link-check@3.13.7
 echo "::group::Debug information"
 npm -g list --depth=1
 echo "::endgroup::"


### PR DESCRIPTION
## What's changed

- Bump markdown-link-check from 3.16.6 to 3.13.7

## Background

markdown-link-check has [fixed an important bug](https://github.com/tcort/markdown-link-check/pull/372/files) in 3.13.7.  

- FYI: https://github.com/tcort/markdown-link-check/releases/tag/v3.13.7

It would be great if github-action-markdown-link-check could also utilize this patch version.


